### PR TITLE
[Bugfix] Fix full width tippy

### DIFF
--- a/dnd5e.css
+++ b/dnd5e.css
@@ -2071,7 +2071,7 @@
   background: #06243a;
 }
 .dnd5e.sheet.actor-alternative .inventory-list .item .item-name {
-  cursor: pointer;
+  cursor: default;
   max-height: 30px;
   overflow: hidden;
 }
@@ -2079,11 +2079,13 @@
   flex: 0 0 30px;
   background-size: 30px;
   margin-right: 5px;
+  cursor: pointer;
 }
 .dnd5e.sheet.actor-alternative .inventory-list .item .item-name h4 {
   margin: 0;
   white-space: nowrap;
   overflow-x: hidden;
+  cursor: pointer;
 }
 .dnd5e.sheet.actor-alternative .inventory-list .item .item-name.rollable:hover .item-image {
   background-image: url("../../icons/svg/d20-grey.svg") !important;

--- a/less/actors.less
+++ b/less/actors.less
@@ -1583,7 +1583,7 @@
 
       // Item Header Name
       .item-name {
-        cursor: pointer;
+        cursor: default;
         max-height: 30px;
         overflow: hidden;
 
@@ -1591,12 +1591,14 @@
           flex: 0 0 30px;
           background-size: 30px;
           margin-right: 5px;
+          cursor: pointer;
         }
 
         h4 {
           margin: 0;
           white-space: nowrap;
           overflow-x: hidden;
+          cursor: pointer;
         }
 
         &.rollable:hover .item-image {

--- a/templates/actors/parts/actor-features.html
+++ b/templates/actors/parts/actor-features.html
@@ -48,7 +48,7 @@
     <ol class="item-list">
     {{#each section.items as |item iid|}}
         <li class="item flexrow {{#if isDepleted}}depleted{{/if}}" data-item-id="{{item._id}}">
-            <div class="item-name flexrow rollable">
+            <div class="item-name flexrow flex--unset rollable">
                 <div class="item-image item-roll-js" style="background-image: url('{{item.img}}')"></div>
                 <h4>{{item.name}}</h4>
             </div>

--- a/templates/actors/parts/actor-forcepowers.html
+++ b/templates/actors/parts/actor-forcepowers.html
@@ -82,7 +82,7 @@
     <ol class="item-list">
     {{#each section.powers as |item i|}}
         <li class="item flexrow" data-item-id="{{item._id}}">
-            <div class="item-name flexrow rollable">
+            <div class="item-name flexrow flex--unset rollable">
                 <div class="item-image item-roll-js" style="background-image: url('{{item.img}}')"></div>
                 <h4>{{item.name}}</h4>
                 {{#if item.data.uses.per }}

--- a/templates/actors/parts/actor-techpowers.html
+++ b/templates/actors/parts/actor-techpowers.html
@@ -81,7 +81,7 @@
     <ol class="item-list">
     {{#each section.powers as |item i|}}
         <li class="item flexrow" data-item-id="{{item._id}}">
-            <div class="item-name flexrow rollable">
+            <div class="item-name flexrow flex--unset rollable">
                 <div class="item-image item-roll-js" style="background-image: url('{{item.img}}')"></div>
                 <h4>{{item.name}}</h4>
                 {{#if item.data.uses.per }}


### PR DESCRIPTION
## Changes
- Set tippy to show only on the tech power name
- Set tippy to show only on the feature name
- Set tippy to show only on the force power name

## Motivation and context
Previously tippy showed on the full width of the name column, which meant it covered the icons to edit and delete an entry